### PR TITLE
added the query name in the Query type of C-SPARQL. 

### DIFF
--- a/csparql-core/src/main/java/eu/larkc/csparql/core/engine/CsparqlEngineImpl.java
+++ b/csparql-core/src/main/java/eu/larkc/csparql/core/engine/CsparqlEngineImpl.java
@@ -240,7 +240,7 @@ public class CsparqlEngineImpl implements Observer, CsparqlEngine {
 		sparqlEngine.removeStaticNamedModel(iri);
 	}
 
-	private CSparqlQuery getQueryByID(final String id) {
+	protected CSparqlQuery getQueryByID(final String id) {
 		for (final CSparqlQuery q : this.queries) {
 			if (q.getId().equalsIgnoreCase(id)) {
 				return q;
@@ -328,6 +328,7 @@ public class CsparqlEngineImpl implements Observer, CsparqlEngine {
 		final CsparqlQueryResultProxy result = new CsparqlQueryResultProxy(query.getId());
 		result.setSparqlQueryId(query.getSparqlQuery().getId());
 		result.setCepQueryId(query.getCepQuery().getId());
+		result.setName(query.getName());
 
 		this.queries.add(query);
 		this.snapshots.put(query, s);
@@ -372,6 +373,7 @@ public class CsparqlEngineImpl implements Observer, CsparqlEngine {
         final CsparqlQueryResultProxy result = new CsparqlQueryResultProxy(query.getId());
         result.setSparqlQueryId(query.getSparqlQuery().getId());
         result.setCepQueryId(query.getCepQuery().getId());
+        result.setName(query.getName());
 
         this.queries.add(query);
         this.snapshots.put(query, s);
@@ -416,6 +418,8 @@ public class CsparqlEngineImpl implements Observer, CsparqlEngine {
 		final CsparqlQueryResultProxy result = new CsparqlQueryResultProxy(query.getId());
 		result.setSparqlQueryId(query.getSparqlQuery().getId());
 		result.setCepQueryId(query.getCepQuery().getId());
+		result.setName(query.getName());
+
 
 		this.queries.add(query);
 		this.snapshots.put(query, s);
@@ -474,6 +478,7 @@ public class CsparqlEngineImpl implements Observer, CsparqlEngine {
 		final CsparqlQueryResultProxy result = new CsparqlQueryResultProxy(query.getId());
 		result.setSparqlQueryId(query.getSparqlQuery().getId());
 		result.setCepQueryId(query.getCepQuery().getId());
+		result.setName(query.getName());
 
 		this.queries.add(query);
 		this.snapshots.put(query, s);

--- a/csparql-core/src/main/java/eu/larkc/csparql/core/engine/CsparqlQueryResultProxy.java
+++ b/csparql-core/src/main/java/eu/larkc/csparql/core/engine/CsparqlQueryResultProxy.java
@@ -44,6 +44,7 @@ import eu.larkc.csparql.common.RDFTuple;
 public class CsparqlQueryResultProxy extends Observable implements NamedObject {
 
 	private String id;
+	private String name;
 	private String sparqlQueryId;
 	private String cepQueryId;
 
@@ -97,5 +98,12 @@ public class CsparqlQueryResultProxy extends Observable implements NamedObject {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+	public void setName(String name){
+		this.name = name;
+	}
+	
+	public String getName(){
+		return name;
 	}
 }

--- a/csparql-core/src/main/java/eu/larkc/csparql/core/new_parser/utility_files/CSparqlTranslator.java
+++ b/csparql-core/src/main/java/eu/larkc/csparql/core/new_parser/utility_files/CSparqlTranslator.java
@@ -63,7 +63,7 @@ public final class CSparqlTranslator extends Translator {
 
 		EplProducer ep = new EplProducer(this.getEngine(), parser.getStreams());
 		Set<String> epls = ep.produceEpl();
-		CSparqlQuery csq = new CSparqlQueryImpl(epls.toArray()[0].toString(), parser.getSparqlQuery(), queryCommand, parser.getStreams());
+		CSparqlQuery csq = new CSparqlQueryImpl(epls.toArray()[0].toString(), parser.getSparqlQuery(), queryCommand, parser.getStreams(), parser.getCsparqlQueryName());
 		return csq;	   
 
 		//REGISTER QUERY abc AS PREFIX ex:     <http://ex.org#> SELECT ?vm FROM STREAM <http://ex.org/stream> [RANGE 30s STEP 15s] WHERE { { SELECT ?vm (PERCENTILE(?resp_time, 0.95) AS ?perc) WHERE { ?vm <http://ex.org#response_time> ?resp_time } GROUP BY ?vm HAVING (?perc > 0) } }

--- a/csparql-core/src/main/java/eu/larkc/csparql/core/streams/formats/CSparqlQuery.java
+++ b/csparql-core/src/main/java/eu/larkc/csparql/core/streams/formats/CSparqlQuery.java
@@ -50,4 +50,6 @@ public interface CSparqlQuery extends NamedObject {
    SparqlQuery getSparqlQuery();
    
    Collection<StreamInfo> getStreams();
+   
+   String getName();
 }

--- a/csparql-core/src/main/java/eu/larkc/csparql/core/streams/formats/CSparqlQueryImpl.java
+++ b/csparql-core/src/main/java/eu/larkc/csparql/core/streams/formats/CSparqlQueryImpl.java
@@ -50,15 +50,16 @@ public class CSparqlQueryImpl implements CSparqlQuery {
    private CepQuery cepQuery = null;
    private SparqlQuery sparqlQuery = null;
    private Collection<StreamInfo> streams;
+   private String name = null;
 
    public CSparqlQueryImpl(final String cepQuery, final String sparqlQuery,
-         final String cSparqlQuery, Collection<StreamInfo> streams) {
+         final String cSparqlQuery, Collection<StreamInfo> streams, String name) {
       this.id = this.generateID();
       this.command = cSparqlQuery;
-      this.sparqlQuery = Configuration.getCurrentConfiguration().createSparqlQuery(
-            sparqlQuery);
+      this.sparqlQuery = Configuration.getCurrentConfiguration().createSparqlQuery(sparqlQuery);
       this.cepQuery = Configuration.getCurrentConfiguration().createCepQuery(cepQuery);
       this.streams = streams;
+      this.name = name;
    }
 
    private String generateID() {
@@ -85,4 +86,8 @@ public class CSparqlQueryImpl implements CSparqlQuery {
    public Collection<StreamInfo> getStreams() {
 		return streams;
 	}
+   
+   public String getName(){
+	   return name;
+   }
 }

--- a/csparql-ui/src/test/java/eu/larck/csparql/ui/ExternalTimestampTests.java
+++ b/csparql-ui/src/test/java/eu/larck/csparql/ui/ExternalTimestampTests.java
@@ -187,7 +187,7 @@ public class ExternalTimestampTests {
 				new long[]{600, 1000, 1340, 1340, 2000, 2000, 2020, 3000, 3001});
 
 		String queryGetAll = 
-				"REGISTER QUERY PIPPO AS SELECT ?S FROM STREAM <http://myexample.org/stream> "
+				"REGISTER QUERY PIPPO AS SELECT FROM STREAM <http://myexample.org/stream> "
 						+ "[RANGE 2s STEP 1s]  "
 						+ "WHERE { ?S ?P ?O }";
 		//				"REGISTER QUERY PIPPO AS SELECT ?O FROM STREAM <http://myexample.org/stream> [RANGE 4s STEP 4s]  WHERE { ?S ?P ?O } ORDER BY ?O";


### PR DESCRIPTION
Now C-SPARQL stores the name of the query if a field, which can be used to retrieve a query by ID. 